### PR TITLE
add checked lambda funcs that can be easily demoted to standard lambdas

### DIFF
--- a/src/main/java/org/mitre/caasd/commons/lambda/CheckedBiFunction.java
+++ b/src/main/java/org/mitre/caasd/commons/lambda/CheckedBiFunction.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2023 The MITRE Corporation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.mitre.caasd.commons.lambda;
+
+import java.util.function.BiFunction;
+
+import org.mitre.caasd.commons.util.DemotedException;
+
+/**
+ * Extension of the {@link BiFunction} interface for a checked lambda function
+ */
+@FunctionalInterface
+public interface CheckedBiFunction<T, U, R> {
+
+    R apply(T t, U u) throws Exception;
+
+    /**
+     * Demote the {@link FunctionalInterface} that throws an {@link Exception} to a
+     * {@link BiFunction}
+     */
+    static <T, U, R> BiFunction<T, U, R> demote(CheckedBiFunction<T, U, R> func) {
+        return (t, u) -> {
+            try {
+                return func.apply(t, u);
+            } catch (Exception e) {
+                throw DemotedException.demote(e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/mitre/caasd/commons/lambda/CheckedBinaryOperator.java
+++ b/src/main/java/org/mitre/caasd/commons/lambda/CheckedBinaryOperator.java
@@ -1,0 +1,43 @@
+/*
+ *    Copyright 2023 The MITRE Corporation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.mitre.caasd.commons.lambda;
+
+import java.util.function.BinaryOperator;
+
+import org.mitre.caasd.commons.util.DemotedException;
+
+/**
+ * Extension of the {@link BinaryOperator} interface for a checked lambda
+ * function
+ */
+@FunctionalInterface
+public interface CheckedBinaryOperator<T> extends CheckedBiFunction<T, T, T> {
+
+    /**
+     * Demote the {@link FunctionalInterface} that throws an {@link Exception} to a
+     * {@link BinaryOperator}
+     */
+    static <T> BinaryOperator<T> demote(CheckedBinaryOperator<T> func) {
+        return (t, u) -> {
+            try {
+                return func.apply(t, u);
+            } catch (Exception e) {
+                throw DemotedException.demote(e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/mitre/caasd/commons/lambda/CheckedFunction.java
+++ b/src/main/java/org/mitre/caasd/commons/lambda/CheckedFunction.java
@@ -1,0 +1,45 @@
+/*
+ *    Copyright 2023 The MITRE Corporation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.mitre.caasd.commons.lambda;
+
+import java.util.function.Function;
+
+import org.mitre.caasd.commons.util.DemotedException;
+
+/**
+ * Extension of the {@link Function} interface for a checked lambda
+ * function
+ */
+@FunctionalInterface
+public interface CheckedFunction<S, T> {
+
+    T apply(S t) throws Exception;
+
+    /**
+     * Demote the {@link FunctionalInterface} that throws an {@link Exception} to a
+     * {@link Function}
+     */
+    static <S, T> Function<S, T> demote(CheckedFunction<S, T> func) {
+        return x -> {
+            try {
+                return func.apply(x);
+            } catch (Exception e) {
+                throw DemotedException.demote(e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/mitre/caasd/commons/lambda/CheckedPredicate.java
+++ b/src/main/java/org/mitre/caasd/commons/lambda/CheckedPredicate.java
@@ -1,0 +1,45 @@
+/*
+ *    Copyright 2023 The MITRE Corporation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.mitre.caasd.commons.lambda;
+
+import java.util.function.Predicate;
+
+import org.mitre.caasd.commons.util.DemotedException;
+
+/**
+ * Extension of the {@link Predicate} interface for a checked lambda
+ * function
+ */
+@FunctionalInterface
+public interface CheckedPredicate<T> {
+
+    boolean test(T t);
+
+    /**
+     * Demote the {@link FunctionalInterface} that throws an {@link Exception} to a
+     * {@link Predicate}
+     */
+    static <T> Predicate<T> demote(CheckedPredicate<T> pred) {
+        return x -> {
+            try {
+                return pred.test(x);
+            } catch (Exception e) {
+                throw DemotedException.demote(e);
+            }
+        };
+    }
+}

--- a/src/main/java/org/mitre/caasd/commons/lambda/Uncheck.java
+++ b/src/main/java/org/mitre/caasd/commons/lambda/Uncheck.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2023 The MITRE Corporation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.mitre.caasd.commons.lambda;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Collection of convenience methods to shorten the syntax when used in
+ * {@link Stream} operators:
+ * 
+ * stream
+ * .filter(Uncheck.pred(x -> checkedTest(x)))
+ * .map(Uncheck.func(x -> checkedFn(x)))
+ */
+public class Uncheck {
+
+    /**
+     * Demote the {@link CheckedFunction} to a {@link BiFunction}
+     */
+    public static <S, T> Function<S, T> func(CheckedFunction<S, T> func) {
+        return CheckedFunction.demote(func);
+    }
+
+    /**
+     * Demote the {@link CheckedPredicate} to a {@link Predicate}
+     */
+    public static <S, T> Predicate<T> pred(CheckedPredicate<T> func) {
+        return CheckedPredicate.demote(func);
+    }
+
+    /**
+     * Demote the {@link CheckedBiFunction} to a {@link CheckedBiFunction}
+     */
+    public static <T, U, R> BiFunction<T, U, R> bifunc(CheckedBiFunction<T, U, R> func) {
+        return CheckedBiFunction.demote(func);
+    }
+
+    /**
+     * Demote the {@link CheckedBinaryOperator} to a {@link BinaryOperator}
+     */
+    public static <T> BinaryOperator<T> biop(CheckedBinaryOperator<T> func) {
+        return CheckedBinaryOperator.demote(func);
+    }
+
+}


### PR DESCRIPTION
Allows two options for calls:
```java
stream
  .filter(CheckedPredicate.demote(x -> checkedTest(x)))
  .map(CheckedFunction.demote(x -> checkedCall(x)))
  ...
```
or
```java
stream
  .filter(Uncheck.pred(x -> checkedTest(x)))
  .map(Uncheck.func(x -> checkedCall(x)))
  ...
```

I'm not to particular about the specific labels for the methods, just that having 'short' calls will help readability a lot