### PR TITLE
Id as rand

### DIFF
--- a/src/main/java/org/mitre/caasd/commons/ids/TimeId.java
+++ b/src/main/java/org/mitre/caasd/commons/ids/TimeId.java
@@ -21,7 +21,6 @@ import static java.time.Instant.now;
 import static java.util.Objects.requireNonNull;
 import static org.mitre.caasd.commons.util.BitAndHashingUtils.makeBitMask;
 import java.io.Serializable;
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;

--- a/src/main/java/org/mitre/caasd/commons/ids/TimeId.java
+++ b/src/main/java/org/mitre/caasd/commons/ids/TimeId.java
@@ -21,6 +21,7 @@ import static java.time.Instant.now;
 import static java.util.Objects.requireNonNull;
 import static org.mitre.caasd.commons.util.BitAndHashingUtils.makeBitMask;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
@@ -188,6 +189,27 @@ public class TimeId implements Comparable<TimeId>, HasTime, Serializable {
             .putLong(randomBits)
             .putLong(rightBits)
             .array();
+    }
+
+    private static final long SIXTY_THREE_BIT_MASK = Long.parseLong("7fffffffffffffff", 16);
+
+    /**
+     * Converts 63 random bits in this TimeId to a uniform random variable. This method supports
+     * randomized data sampling algorithms for cases when every piece of data is labeled with a
+     * TimeId.
+     * <p>
+     * Warning: DO NOT rely on this value for hashing. The double returned here is derived from only
+     * 63 random bits. Thus, the probability of hash-collision will increase.
+     *
+     * @return A uniform random number between 0 and 1, based on 63 random bits
+     */
+    public double asUniformRand() {
+
+        //Isolate 63 pseudo-random bits within the "right bits"
+        long randomBits = rightBits & SIXTY_THREE_BIT_MASK;
+        long maxPossibleValue = SIXTY_THREE_BIT_MASK;
+
+        return (double) randomBits / (double) maxPossibleValue;
     }
 
     /**

--- a/src/test/java/org/mitre/caasd/commons/ids/TimeIdTest.java
+++ b/src/test/java/org/mitre/caasd/commons/ids/TimeIdTest.java
@@ -32,9 +32,8 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
@@ -308,19 +307,22 @@ class TimeIdTest {
     }
 
     @Test
-    public void asUniformIsLossy() {
+    public void demo_uniformRand_forRandomSampling() {
 
-        long bitMask = makeBitMask(63);
+        //NOT A UNIT TEST -- Demonstration only...
 
-        System.out.println(Long.toHexString(bitMask));
+        int DATA_SET_SIZE = 1000;
+        int SAMPLE_SIZE = 20;
 
-        System.out.println(Long.toBinaryString(bitMask));
-
-
-
-        long bitMask2 = Long.parseLong("7fffffffffffffff", 16);
-        System.out.println(Long.toBinaryString(bitMask2));
-
-
+        //Make a dataset
+        Map<TimeId, Integer> someKeyedData = new HashMap<>();
+        IntStream.range(0, DATA_SET_SIZE).forEach(i -> someKeyedData.put(newId(), i));
+        
+        //Take a random sample by sorting via the uniform random variable
+        List<Integer> RANDOM_SAMPLE = someKeyedData.entrySet().stream()
+            .sorted(Comparator.comparing(entry -> entry.getKey().asUniformRand()))
+            .limit(SAMPLE_SIZE)
+            .map(entry -> entry.getValue())
+            .collect(Collectors.toList());
     }
 }

--- a/src/test/java/org/mitre/caasd/commons/ids/TimeIdTest.java
+++ b/src/test/java/org/mitre/caasd/commons/ids/TimeIdTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mitre.caasd.commons.ids.TimeId.newId;
 import static org.mitre.caasd.commons.ids.TimeId.newIdFor;
-import static org.mitre.caasd.commons.util.BitAndHashingUtils.makeBitMask;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -317,7 +316,7 @@ class TimeIdTest {
         //Make a dataset
         Map<TimeId, Integer> someKeyedData = new HashMap<>();
         IntStream.range(0, DATA_SET_SIZE).forEach(i -> someKeyedData.put(newId(), i));
-        
+
         //Take a random sample by sorting via the uniform random variable
         List<Integer> RANDOM_SAMPLE = someKeyedData.entrySet().stream()
             .sorted(Comparator.comparing(entry -> entry.getKey().asUniformRand()))


### PR DESCRIPTION
Adding `TimeId.asUniformRand()` to support randomized algorithms