### PR TITLE
Upgrade to use Java toolchain in Gradle build file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,9 @@ tasks {
 }
 
 java {
-    val javaVersion = JavaVersion.VERSION_1_8
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
     withSourcesJar()
     withJavadocJar()
 }


### PR DESCRIPTION
[This](https://docs.gradle.org/current/userguide/building_java_projects.html#introduction) is the standard way to define the Java version in a Gradle build file.

[This section](https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation) explains that

> ... `sourceCompatibility` and `targetCompatibility` properties.
Although not generally advised, these options were historically used to configure the Java version during compilation.