### PR TITLE
Adding CheckedSupplier to suite of Uncheck utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,15 @@ dependencies.
 
 ### Code Formatting
 
-To keep source code consistent this project uses:
+To keep source code formatting consistent this project uses:
 
-- A [checkstyle.xml](docs%2Fcode-style%2Fcheckstyle.xml) style sheet
 - The [spotless](https://github.com/diffplug/spotless) build plugin
+    - This plugin enforces a global code format during the build step (e.g. incorrect formatting breaks the build).
+    - Auto-format your code using: `./gradlew :spotlessApply`
+- A [checkstyle.xml](docs%2Fcode-style%2Fcheckstyle.xml) style sheet.
+    - The spotless plugin has priority,
+    - The goal of the style sheet is to configure your IDE so the spotless plugin and your IDE mostly agree on
+      formatting
 
 ### About Dependencies
 

--- a/src/main/java/org/mitre/caasd/commons/lambda/CheckedSupplier.java
+++ b/src/main/java/org/mitre/caasd/commons/lambda/CheckedSupplier.java
@@ -1,0 +1,38 @@
+package org.mitre.caasd.commons.lambda;
+
+import java.util.function.Supplier;
+
+/**
+ * A CheckedSupplier is similar to a {@link Supplier} EXCEPT it throws a checked exception.
+ * <p>
+ * Unfortunately, a CheckedSupplier obfuscates code because they require using try-catch blocks.
+ * This class and the convenience functions in {@link Uncheck}, allow you to improve the readability
+ * of code (assuming you are willing to demote all checked exceptions to RuntimeExceptions).
+ * <p>
+ * For example:
+ *
+ * <pre>{@code
+ *     //code WITHOUT these utilities -- is harder to read and write
+ *     Stream<String> fileLines = null;
+ *     try {
+ *         fileLines = java.nio.lines(pathThFile);
+ *     } catch (IOException ex) {
+ *         throw DemotedException.demote(ex);
+ *     }
+ *     List<String> subset = fileLines.stream()
+ *         .filter(str -> str.contains("abcde"))
+ *         .toList();
+ *
+ *
+ *     //code WITH these utilities -- is easier to read and write
+ *     Stream<String> fileLines = Uncheck.supplier(() -> java.nio.lines(pathThFile));
+ *     List<String> subset = fileLines.stream()
+ *         .filter(str -> str.contains("abcde"))
+ *         .toList();
+ * }</pre>
+ */
+@FunctionalInterface
+public interface CheckedSupplier<T> {
+
+    T get() throws Exception;
+}

--- a/src/test/java/org/mitre/caasd/commons/lambda/UncheckTest.java
+++ b/src/test/java/org/mitre/caasd/commons/lambda/UncheckTest.java
@@ -156,6 +156,39 @@ public class UncheckTest {
         assertThat(result, is("redgreenyellow"));
     }
 
+    @Test
+    public void testCheckedSupplier_happyPath() {
+
+        CheckedSupplier<String> brokenSupplier = () -> "hello";
+
+        assertDoesNotThrow(() -> Uncheck.supplier(brokenSupplier).get());
+    }
+
+    @Test
+    public void testCheckedSupplier_failing() {
+
+        // Part 1 of test:  Checked Exceptions are wrapped in a DemotedException
+
+        CheckedSupplier<String> brokenSupplierCheckedException = () -> {
+            throw new ParseException("I always fail", 0);
+        };
+
+        DemotedException ex =
+                assertThrows(DemotedException.class, () -> Uncheck.supplier(brokenSupplierCheckedException)
+                        .get());
+
+        assertThat(ex.getCause(), instanceOf(ParseException.class));
+
+        // Part 2 of test:  RuntimeExceptions are not wrapped in a DemotedException
+
+        CheckedSupplier<String> brokenSupplierRuntimeException = () -> {
+            throw new UnsupportedOperationException("I always fail");
+        };
+
+        assertThrows(UnsupportedOperationException.class, () -> Uncheck.supplier(brokenSupplierRuntimeException)
+                .get());
+    }
+
     public enum Color {
         RED,
         ORANGE,


### PR DESCRIPTION
Now easier to demote checked exceptions when creating objects.

This is particularly useful when using Files and demoting IOExceptions