### PR TITLE
Fixing LatLong interpolation bug

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,11 +1,13 @@
 # Release Notes
 
+### Version 0.0.57 (Released 2025-01-13)
+- Fixed issue with interpolating LatLong data near the international date line.
+
 ### Version 0.0.56 (Released 2024-12-26)
 
 - Added `LatLong64` and `LatLong64Path`. These lossy compressed editions of `LatLong` and `LatLongPath` reduce the number of
   bytes required to store lat/long data by 50%.
     -  See `LatLong.compress()` and `LatLongPath.compress()`
-- Fixed issue with interpolating LatLong data near the international date line
 
 ### Version 0.0.55 (Released 2024-11-14)
 

--- a/src/main/java/org/mitre/caasd/commons/LatLong.java
+++ b/src/main/java/org/mitre/caasd/commons/LatLong.java
@@ -156,6 +156,28 @@ public class LatLong implements Comparable<LatLong>, Serializable {
         }
     }
 
+    /**
+     * Clamps the provided latitude value to the closed range [-90,90]
+     *
+     * @param latitude A candidate latitude value that could be outside the legal range
+     *
+     * @return Math.min(90.0, Math.max (latitude, - 90.0));
+     */
+    public static double clampLatitude(double latitude) {
+        return Math.min(90.0, Math.max(latitude, -90.0));
+    }
+
+    /**
+     * Clamps the provided longitude value to the closed range [-180,180]
+     *
+     * @param longitude A candidate longitude value that could be outside the legal range
+     *
+     * @return Math.min(180.0, Math.max (longitude, - 180.0));
+     */
+    public static double clampLongitude(double longitude) {
+        return Math.min(180, Math.max(longitude, -180.0));
+    }
+
     public double latitude() {
         return latitude;
     }

--- a/src/test/java/org/mitre/caasd/commons/LatLongTest.java
+++ b/src/test/java/org/mitre/caasd/commons/LatLongTest.java
@@ -70,6 +70,32 @@ public class LatLongTest {
     }
 
     @Test
+    void clampLatitude_spec() {
+        assertThat(clampLatitude(Double.NEGATIVE_INFINITY), is(-90.0));
+        assertThat(clampLatitude(-90.001), is(-90.0));
+        assertThat(clampLatitude(-90.0), is(-90.0));
+        assertThat(clampLatitude(-89.999), is(-89.999));
+
+        assertThat(clampLatitude(Double.POSITIVE_INFINITY), is(90.0));
+        assertThat(clampLatitude(90.001), is(90.0));
+        assertThat(clampLatitude(90.00), is(90.0));
+        assertThat(clampLatitude(89.999), is(89.999));
+    }
+
+    @Test
+    void clampLongitude_spec() {
+        assertThat(clampLongitude(Double.NEGATIVE_INFINITY), is(-180.0));
+        assertThat(clampLongitude(-180.001), is(-180.0));
+        assertThat(clampLongitude(-180.0), is(-180.0));
+        assertThat(clampLongitude(-179.999), is(-179.999));
+
+        assertThat(clampLongitude(Double.POSITIVE_INFINITY), is(180.0));
+        assertThat(clampLongitude(180.01), is(180.0));
+        assertThat(clampLongitude(180.00), is(180.0));
+        assertThat(clampLongitude(179.999), is(179.999));
+    }
+
+    @Test
     public void testEqualsAndHashcode() {
         LatLong one = new LatLong(45.0, 45.0);
         LatLong two = new LatLong(45.0, 45.0);

--- a/src/test/java/org/mitre/caasd/commons/math/locationfit/LocalPolyInterpolatorTest.java
+++ b/src/test/java/org/mitre/caasd/commons/math/locationfit/LocalPolyInterpolatorTest.java
@@ -523,6 +523,28 @@ public class LocalPolyInterpolatorTest {
     }
 
     @Test
+    public void brokenExample_nearInternationalDateLine() {
+        // FAILURE LOGS =
+        //
+        // Longitude is out of range: -180.00084537630087
+        // Could not interpolate input data.
+        //        sampleTime= 2024-11-10T20:13:16.705Z
+        // 11/10/2024,20:13:03.584,52.3755,-179.9606
+        // 11/10/2024,20:13:07.745,52.3764,-179.9725
+        // 11/10/2024,20:13:11.805,52.3774,-179.984
+        // 11/10/2024,20:13:16.705,52.3786,-179.998
+        PositionRecord<Dummy> p1 = parseTestInput("11/10/2024,20:13:03.584,52.3755,-179.9606");
+        PositionRecord<Dummy> p2 = parseTestInput("11/10/2024,20:13:07.745,52.3764,-179.9725");
+        PositionRecord<Dummy> p3 = parseTestInput("11/10/2024,20:13:11.805,52.3774,-179.984");
+        PositionRecord<Dummy> p4 = parseTestInput("11/10/2024,20:13:16.705,52.3786,-179.998");
+        LocalPolyInterpolator interpolator = new LocalPolyInterpolator(Duration.ofSeconds(60), 3, true);
+        Optional<KineticRecord<Dummy>> result =
+                interpolator.floorInterpolate(newArrayList(p1, p2, p3, p4), Instant.parse("2024-11-10T20:13:16.705Z"));
+
+        assertThat(result.isPresent(), is(true));
+    }
+
+    @Test
     public void brokenExample_duplicate_time_and_position_2() {
 
         // FAILURE LOGS =


### PR DESCRIPTION
* Fix issue where interpolated longitude can be flawed near international date line
* Added LatLong.clampLatitude(double)
* Added LatLong.clampLongitude(double)