### PR TITLE
Fix Renovate enabledManagers so all extended presets take effect

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "github-actions",
+    "gradle",
+    "gradle-wrapper"
+  ],
   "extends": [
     "github>cre-security/renovate-controller",
     "github>mitre-tdp/tdp-renovate:gradle.json5",


### PR DESCRIPTION
## Problem

This repo extends multiple `mitre-tdp/tdp-renovate` presets, but had **no top-level `enabledManagers`**. Each preset sets its own `enabledManagers`, and Renovate **replaces (does not union)** that array across the `extends` chain — so only the **last** preset's managers were active. The other managers (gradle, gradle-wrapper) were silently disabled.

## Fix

Declare the full manager set at the top level (the union of the extended presets), matching the issue-502 standard and the already-correct repos (e.g. `maestro`, `swim-relay`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)